### PR TITLE
nix: move derivation under attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,24 @@
 with import <nixpkgs> {};
 
-rustPlatform.buildRustPackage {
-  pname = "doxie-upload";
-  version = "0.2.0-dev";
+{
+  doxie-upload = rustPlatform.buildRustPackage {
+    pname = "doxie-upload";
+    version = "0.2.0-dev";
 
-  cargoLock = {
-    lockFile = ./Cargo.lock;
+    cargoLock = {
+      lockFile = ./Cargo.lock;
 
-    outputHashes = {
-      "multipart-async-0.0.2" = "sha256-C3vrrYf7zeQGfGqHtoCdosWhC+sF3Xmx9g/MEFzrXMc=";
+      outputHashes = {
+        "multipart-async-0.0.2" = "sha256-C3vrrYf7zeQGfGqHtoCdosWhC+sF3Xmx9g/MEFzrXMc=";
+      };
     };
-  };
 
-  src = ./.;
+    src = ./.;
 
-  meta = with lib; {
-    description = "Simple HTTP server for accepting scans from Doxie scanners";
-    homepage = "https://github.com/crawford/doxie-upload";
-    license = licenses.agpl3Plus;
+    meta = with lib; {
+      description = "Simple HTTP server for accepting scans from Doxie scanners";
+      homepage = "https://github.com/crawford/doxie-upload";
+      license = licenses.agpl3Plus;
+    };
   };
 }


### PR DESCRIPTION
Hydra expects an attrset:

    Jobset contains a job with an empty name. Make sure the jobset
    evaluates to an attrset of jobs.